### PR TITLE
Add initial Discord features and Docker configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# .env files
+*.env
+
+# virtualenv
+
+venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@
 # virtualenv
 
 venv/*
+
+# secrets
+op_service_account_token.txt
+# .env files
+*.env
+
+# virtualenv
+
+venv/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9.6
+
+COPY requirements.txt
+RUN pip install -r requirements.txt
+
+COPY main.py .
+RUN --mount=type=secret,id=token_id TOKEN_ID=$(cat /run/secrets/token_id)
+CMD ["python","./main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
 FROM python:3.9.6
 
-COPY requirements.txt
+COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
-COPY main.py .
-RUN --mount=type=secret,id=token_id TOKEN_ID=$(cat /run/secrets/token_id)
-CMD ["python","./main.py"]
+COPY main.py ./
+
+COPY --from=1password/op:2 /usr/local/bin/op /usr/local/bin/op
+
+ENV DISCORD_TOKEN="op://Personal Dev Vault/DISCORD_TOKEN/password"
+ENV APP_ID="op://Personal Dev Vault/APP_ID/password"
+ENV PUBLIC_KEY="op://Personal Dev Vault/PUBLIC_KEY/password"
+ENV GUILD_ID="op://Personal Dev Vault/GUILD_ID/password"
+ENV CHANNEL_ID="op://Personal Dev Vault/CHANNEL_ID/password"
+ENV INTENTS="op://Personal Dev Vault/INTENTS/password"
+ENV CHANNEL_CATEGORY="op://Personal Dev Vault/CHANNEL_CATEGORY/password"
+
+CMD export OP_SERVICE_ACCOUNT_TOKEN=$(cat run/secrets/op_service_account_token) && op run -- python ./main.py

--- a/README.md
+++ b/README.md
@@ -1,59 +1,17 @@
 # our_discord_server
 A place to work with my friend group's discord server
 
+## Bot Functionality
+
+### Event Management
+
+- When a scheduled event is created the bot creates a new private channel named after the event and adds the event creator to it. 
+- When a user clicks "interested" on a scheduled event they are added to the existing channel for the event. 
+- Introduces bot command `?get_guild_events` which lists all scheduled events for the coming week. 
+
+#TODO: 
+- Add arguments for start date and number of days to list to `$get_guild_events`.
+- Add functionality to delete channels after event occurs
+- Add user facing read-me for events
 
 
-FROM python:3.9.6
-
-ENV DISCORD_TOKEN="op://Personal Dev Vault/DISCORD_TOKEN/password"
-
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-COPY main.py .
-
-# uses the user's specified shell
-RUN sudo -s \
-curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
-gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
-
-
-# This goes and gets the public key for the apt download and converts it to gpg
-# -S, --show-error
-#               When used with -s, --silent, it makes curl show an error
-#               message if it fails.
-
-#               This option is global and does not need to be specified
-#               for each use of --next.
-
-#               Providing -S, --show-error multiple times has no extra
-#               effect.  Disable it again with --no-show-error.
-
-#               Example:
-#                curl --show-error --silent https://example.com
-
-#               See also --no-progress-meter.
-
-
-# The gpg is an acronym for “GnuPrivacy Guard”. It encrypts your files securely so that only the specified receiver can decrypt those files. GPG is based on the concept of each user having two encryption keys. Each individual can have a pair of public and private keys.
-
-# https://www.digitalocean.com/community/tutorials/how-to-handle-apt-key-and-add-apt-repository-deprecation-using-gpg-to-add-external-repositories-on-ubuntu-22-04
-
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
-sudo tee /etc/apt/sources.list.d/1password.list
-
-# Add the debsig policy
-
-RUN sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
-RUN curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | \
-sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
-RUN sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
-RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
-sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
-
-# update and install the 1password-cli
-
-RUN sudo apt update && sudo apt install 1password-cli
-
-RUN export "DISCORD_TOKEN=op://Personal Dev Vault/DISCORD_TOKEN/password"
-
-CMD ["op run","--env-file=./.env" python ./main.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
 # our_discord_server
 A place to work with my friend group's discord server
+
+
+
+FROM python:3.9.6
+
+ENV DISCORD_TOKEN="op://Personal Dev Vault/DISCORD_TOKEN/password"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY main.py .
+
+# uses the user's specified shell
+RUN sudo -s \
+curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+
+
+# This goes and gets the public key for the apt download and converts it to gpg
+# -S, --show-error
+#               When used with -s, --silent, it makes curl show an error
+#               message if it fails.
+
+#               This option is global and does not need to be specified
+#               for each use of --next.
+
+#               Providing -S, --show-error multiple times has no extra
+#               effect.  Disable it again with --no-show-error.
+
+#               Example:
+#                curl --show-error --silent https://example.com
+
+#               See also --no-progress-meter.
+
+
+# The gpg is an acronym for “GnuPrivacy Guard”. It encrypts your files securely so that only the specified receiver can decrypt those files. GPG is based on the concept of each user having two encryption keys. Each individual can have a pair of public and private keys.
+
+# https://www.digitalocean.com/community/tutorials/how-to-handle-apt-key-and-add-apt-repository-deprecation-using-gpg-to-add-external-repositories-on-ubuntu-22-04
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
+sudo tee /etc/apt/sources.list.d/1password.list
+
+# Add the debsig policy
+
+RUN sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+RUN curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | \
+sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
+RUN sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+
+# update and install the 1password-cli
+
+RUN sudo apt update && sudo apt install 1password-cli
+
+RUN export "DISCORD_TOKEN=op://Personal Dev Vault/DISCORD_TOKEN/password"
+
+CMD ["op run","--env-file=./.env" python ./main.py"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  web:
+    build: .
+    secrets:
+      - op_service_account_token
+
+secrets:
+  op_service_account_token:
+    file: ./op_service_account_token.txt

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+import os
+from datetime import datetime, timedelta
+
+import discord
+from discord.ext import commands, tasks
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+#env variables
+guild_id = int(os.getenv('GUILD_ID'))
+
+
+intents = discord.Intents.default()
+intents.members = True
+intents.message_content = True
+
+bot = commands.Bot(command_prefix = '?',intents=intents)
+
+@bot.command()
+async def get_guild_events(ctx):
+    #TODO add arguments for start date and number of days to list
+
+    guild = bot.get_guild(guild_id)
+    all_events = guild.scheduled_events
+
+    event_ids = [event.id for event in guild.scheduled_events]
+
+    events = [guild.get_scheduled_event(id) for id in event_ids]
+
+    print_date = datetime.today().date()+timedelta(1)
+
+    message = []
+
+    message.append("## It is I, Baphomet... Behold!\n ## This week's events.. \n\n\n")
+    for day in range(7):
+
+        if print_date in [event.start_time.date() for event in events]:
+
+            formatted_date = print_date.strftime('%A %B %d')
+
+            message.append(f" \n### {formatted_date}")  
+
+            for event in events:
+                if event.start_time.date() == print_date:
+                    message.append(event.url)
+            
+        print_date = print_date+timedelta(1)
+
+    await ctx.send("\n".join([m for m in message]),suppress_embeds=True)
+
+bot.run(os.getenv('DISCORD_TOKEN'))
+

--- a/main.py
+++ b/main.py
@@ -1,39 +1,90 @@
 import os
+import re
 from datetime import datetime, timedelta
 
 import discord
 from discord.ext import commands, tasks
+from discord.utils import get
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-#env variables
 guild_id = int(os.getenv('GUILD_ID'))
 
-
-intents = discord.Intents.default()
+intents = discord.Intents.all()
 intents.members = True
 intents.message_content = True
 
-bot = commands.Bot(command_prefix = '?',intents=intents)
+bot = commands.Bot(command_prefix ='?',intents=intents)
+
+
+def convert_to_channel_name(event_name):
+    """ Helper function that takes a string name of an event and returns how it has to be formatted for a channel name"""
+    channel_name = re.sub(r'[^a-z0-9\-]','',event_name.replace(' ','-').lower())
+    return channel_name
+
+@bot.event
+async def on_scheduled_event_create(event):
+    """ 
+    When an event is created, create a text channel and add the event creator to it.
+    requires Intents.guild_scheduled_events and manage_channels to be enabled
+    """
+    # requires Intents.guild_scheduled_events to be enabled
+    # requires manage_channels
+    print("a new event has been created!")
+    guild = event.guild
+    overwrites = {
+        bot.user: discord.PermissionOverwrite(read_messages=True,
+    send_messages=True, read_message_history = True, view_channel=True),
+        event.creator: discord.PermissionOverwrite(read_messages=True,
+    send_messages=True, read_message_history = True, view_channel=True)
+    }
+    category = get(guild.categories, name="Events")
+    await guild.create_text_channel(event.name,category=category)
+    
+ 
+
+@bot.event
+async def on_scheduled_event_user_add(event,user):
+    """ 
+    When a user is added to the event, add the user to the event's text channel.
+    """
+
+    guild = event.guild
+    channel_name = convert_to_channel_name(event.name)
+
+    channel = get(guild.channels,name=channel_name)
+
+    if user in channel.members:
+        print("user already in channel")
+        return
+    else:
+        viewer_permissions = {
+            "read_message_history":True,
+            "read_messages":True,
+            "send_messages":True,
+            "view_channel":True
+        }
+
+        await channel.set_permissions(user, **viewer_permissions)
+
 
 @bot.command()
 async def get_guild_events(ctx):
     #TODO add arguments for start date and number of days to list
+    
+    all_events = ctx.guild.scheduled_events
 
-    guild = bot.get_guild(guild_id)
-    all_events = guild.scheduled_events
+    event_ids = [event.id for event in ctx.guild.scheduled_events]
 
-    event_ids = [event.id for event in guild.scheduled_events]
-
-    events = [guild.get_scheduled_event(id) for id in event_ids]
+    events = [ctx.guild.get_scheduled_event(id) for id in event_ids]
 
     print_date = datetime.today().date()+timedelta(1)
 
     message = []
 
-    message.append("## It is I, Baphomet... Behold!\n ## This week's events.. \n\n\n")
+    message.append("##  BEHOLD!\n ## This week's events.. \n\n\n")
     for day in range(7):
 
         if print_date in [event.start_time.date() for event in events]:

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import discord
 from discord.ext import commands, tasks
 from discord.utils import get
+from discord.utils import get
 
 from dotenv import load_dotenv
 
@@ -25,7 +26,7 @@ def convert_to_channel_name(event_name):
     return channel_name
 
 @bot.event
-async def on_scheduled_event_create(event):
+async def on_scheduled_event_create(event): 
     """ 
     When an event is created, create a text channel and add the event creator to it.
     requires Intents.guild_scheduled_events and manage_channels to be enabled

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+aiofile==3.8.7
+aiohttp==3.8.5
+aiosignal==1.3.1
+async-timeout==4.0.3
+attrs==23.1.0
+caio==0.9.12
+charset-normalizer==3.2.0
+DateTime==5.2
+discord.py==2.3.2
+frozenlist==1.4.0
+idna==3.4
+load-dotenv==0.1.0
+multidict==6.0.4
+python-dotenv==1.0.0
+pytz==2023.3
+yarl==1.9.2
+zope.interface==6.0


### PR DESCRIPTION
This PR set ups the basic project structure and initial features for a discord bot.  


- add gitignore
  - Note that I am passing secrets to Dockerfile (only running locally currently) using a .txt that has been added to gitignore
- add Dockerfile
  - This is suitable for local development. Need to add CI/CD before deploying.
  - I am using a service user created in my personal 1Password account to store secrets
- add README.md
  - This is a very basic README and is geared towards developers, not the end users
- add requirements.txt
- add main.py
  - Using the [discordpy](https://discordpy.readthedocs.io/en/stable/) library
  - Features:
    - On scheduled event creation creates a new channel and adds event creator to channel. 
    - When user clicks "interested" on event adds user to event channel
    - Introduces `?get_guild_events` bot command to list events for upcoming week
