### PR TITLE
Pass API token explicitly to doctl command

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,7 +25,7 @@ jobs:
         token: ${{ secrets.DOCTL_API_TOKEN }}
 
     - name: Log in to DigitalOcean Container Registry with short-lived credentials
-      run: doctl registry login --expiry-seconds 600
+      run: doctl registry login --expiry-seconds 600 -t ${{ secrets.DOCT_API_TOKEN }}
 
     - name: Push image to DigitalOcean Container Registry
       run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server:$(echo $GITHUB_SHA | head -c7)


### PR DESCRIPTION
`doct_registry_login` had failed with a 403. I think I need to pass the token explicitly even though it was passed in the prior step.