### PR TITLE
rework deployment strategy

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,9 +29,3 @@ jobs:
 
     - name: Push image to DigitalOcean Container Registry
       run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server:$(echo $GITHUB_SHA | head -c7)
-
-    - name: Update deployment file
-      run: TAG=$(echo $GITHUB_SHA | head -c7) && sed -i 's|<IMAGE>|registry.digitalocean.com/unicornariel1-continer-registry/our_discord_server:'${TAG}'|' $GITHUB_WORKSPACE/deploy.sh
-    
-    - name: Provision Droplet and deploy container
-      run: doctl compute droplet create "our-discord-server" --image docker-18-04 --size s-1vcpu-1gb --region sfo2 --ssh-keys ${{ secrets.SSH_PUBLIC_KEY_FINGERPRINT }} --user-data-file deploy.sh --wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ENV CHANNEL_ID="op://Personal Dev Vault/CHANNEL_ID/password"
 ENV INTENTS="op://Personal Dev Vault/INTENTS/password"
 ENV CHANNEL_CATEGORY="op://Personal Dev Vault/CHANNEL_CATEGORY/password"
 
-CMD export OP_SERVICE_ACCOUNT_TOKEN=$(cat run/secrets/op_service_account_token) && op run -- python ./main.py
+CMD op run -- python ./main.py

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,2 +1,1 @@
 #!/bin/bash
-docker compose up


### PR DESCRIPTION
Changing my deployment strategy to use a static server that will handle secrets separately. This PR removes the GHA workflow steps that create the server. 