### PR TITLE
Add main to workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:
+      - main
       - staging
 
 jobs:
@@ -10,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout staging
-      uses: actions/checkout@v2
+    - name: Checkout branch
+      uses: actions/checkout@v4
 
     - name: Update SHA
       run: echo $GITHUB_SHA > $GITHUB_WORKSPACE/_meta
 
     - name: Build container image
-      run: docker build -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server:$(echo $GITHUB_SHA | head -c7) .
+      run: docker build -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.ref }}:$(echo $GITHUB_SHA | head -c7) .
 
     - name: Install doctl
       uses: digitalocean/action-doctl@v2
@@ -28,4 +29,4 @@ jobs:
       run: doctl registry login --expiry-seconds 600 -t ${{ secrets.DOCTL_API_TOKEN }}
 
     - name: Push image to DigitalOcean Container Registry
-      run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server:latest
+      run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.ref }}:latest


### PR DESCRIPTION
This PR allows workflow to push `staging` and `main` branches to different container registries. 