### PR TITLE
use base_ref instead of ref

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,8 +20,8 @@ jobs:
     - name: Build container image
       run: | 
         docker build \
-        -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.ref }}:$(echo $GITHUB_SHA | head -c7) \
-        -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.ref }}:latest .
+        -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.base_ref }}:$(echo $GITHUB_SHA | head -c7) \
+        -t registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.base_ref }}:latest .
 
     - name: Install doctl
       uses: digitalocean/action-doctl@v2
@@ -32,5 +32,5 @@ jobs:
       run: doctl registry login --expiry-seconds 600 -t ${{ secrets.DOCTL_API_TOKEN }}
 
     - name: Push image to DigitalOcean Container Registry
-      run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.ref }}:latest
+      run: docker push registry.digitalocean.com/unicornariel1-container-registry/our_discord_server_${{ github.base_ref }}:latest
  


### PR DESCRIPTION
This PR switches from `{{ github.ref }}` to `{{ github.base_ref }}`. `{{ github.ref }}` uses the fully qualified branch name which is not what I want. The intent here is to label the container images with either `staging` or `main`.