### PR TITLE
use env context instead of secrets context

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,7 +5,7 @@ on:
       - staging
 
 env:
-  OP_VAULT: ${{ secrets.OP_VAULT }}
+  OP_VAULT: ${{ vars.OP_VAULT }}
 
 jobs:
 


### PR DESCRIPTION
I originally had wanted to use the secrets context for the name of the vault, but it's not really a secret and the secrets context is more limited so switching over to the vars context.