### PR TITLE
set environment in workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build, push, and deploy
     runs-on: ubuntu-latest
+    environment: {{ github.ref_name }}
     steps:
 
     - name: Checkout branch


### PR DESCRIPTION
The documentation around environmental variables vs using the env context in GHA was a little confusing. I think we need to set the environment explicitly in the workflow.