### PR TITLE
don't need to pip install logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ discord.py==2.4.0
 frozenlist==1.4.0
 idna==3.4
 load-dotenv==0.1.0
-logging==0.4.9.6
 multidict==6.0.4
 pi==0.1.2
 psycopg==3.2.3


### PR DESCRIPTION
logging is a built in library and doesn't need to be installed. 